### PR TITLE
Add the repository field to Cargo.toml

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 description = "A cross-language, common API YAML reference framework"
 license = "MIT"
 readme = "ReadMe.md"
+repository = "https://github.com/yaml/yamlstar"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.